### PR TITLE
Upgrade Cake to 0.17.0

### DIFF
--- a/Cake.Squirrel/Cake.Squirrel.csproj
+++ b/Cake.Squirrel/Cake.Squirrel.csproj
@@ -33,8 +33,8 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Cake.Core, Version=0.11.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Cake.Core.0.11.0\lib\net45\Cake.Core.dll</HintPath>
+    <Reference Include="Cake.Core, Version=0.17.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Cake.Core.0.17.0\lib\net45\Cake.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/Cake.Squirrel/SquirrelAliases.cs
+++ b/Cake.Squirrel/SquirrelAliases.cs
@@ -61,7 +61,7 @@ namespace Cake.Squirrel {
             if (nugetPackage == null) {
                 throw new ArgumentNullException(nameof(nugetPackage));
             }
-            var runner = new SquirrelRunner(context.FileSystem, context.Environment, context.Globber, context.ProcessRunner);
+            var runner = new SquirrelRunner(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
             runner.Run(nugetPackage, settings);
         }
 
@@ -101,7 +101,7 @@ namespace Cake.Squirrel {
             {
                 throw new ArgumentNullException(nameof(nugetPackage));
             }
-            var runner = new SquirrelRunner(context.FileSystem, context.Environment, context.Globber, context.ProcessRunner);
+            var runner = new SquirrelRunner(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
             runner.Run(nugetPackage, settings, new ProcessSettings { RedirectStandardOutput = redirectStandardOutput, Silent = silent});
         }
     }

--- a/Cake.Squirrel/SquirrelRunner.cs
+++ b/Cake.Squirrel/SquirrelRunner.cs
@@ -9,16 +9,15 @@ namespace Cake.Squirrel {
     /// The Squirrel package runner.
     /// </summary>
     public class SquirrelRunner : Tool<SquirrelSettings> {
-
         /// <summary>
         /// Initializes a new instance of the <see cref="SquirrelRunner"/> class.
         /// </summary>
         /// <param name="fileSystem"></param>
         /// <param name="environment"></param>
-        /// <param name="globber"></param>
         /// <param name="processRunner"></param>
-        public SquirrelRunner(IFileSystem fileSystem, ICakeEnvironment environment, IGlobber globber, IProcessRunner processRunner)
-            : base(fileSystem, environment, processRunner, globber) {
+        /// <param name="tools"></param>
+        public SquirrelRunner(IFileSystem fileSystem, ICakeEnvironment environment, IProcessRunner processRunner, IToolLocator tools)
+            : base(fileSystem, environment, processRunner, tools) {
            
         }
         

--- a/Cake.Squirrel/packages.config
+++ b/Cake.Squirrel/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Cake.Core" version="0.11.0" targetFramework="net45" />
+  <package id="Cake.Core" version="0.17.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Cake 0.18.0 will requires at least version 0.16.x to work.